### PR TITLE
Afk 28 portfolio cms collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+/public/media
+
 *storybook.log

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -21,6 +21,12 @@ import { InlineCodeFeatureClient as InlineCodeFeatureClient_e70f5e05f09f93e00b99
 import { SuperscriptFeatureClient as SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { SubscriptFeatureClient as SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
+import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaTitleComponent as MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { SlugComponent as SlugComponent_92cc057d0a2abb4f6cf0307edf59f986 } from '@/fields/slug/SlugComponent'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -45,5 +51,11 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#InlineCodeFeatureClient": InlineCodeFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#SuperscriptFeatureClient": SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#SubscriptFeatureClient": SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864
+  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaTitleComponent": MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@/fields/slug/SlugComponent#SlugComponent": SlugComponent_92cc057d0a2abb4f6cf0307edf59f986
 }

--- a/src/app/(portfolio)/[locale]/page.tsx
+++ b/src/app/(portfolio)/[locale]/page.tsx
@@ -1,4 +1,6 @@
 import Masonry from "@/components/molocules/MasonryGrid/MasonryGrid";
+import { Media, Portfolio } from "@/payload-types";
+import { getCachedGlobal } from "@/utilities/getGlobals";
 import { setRequestLocale } from "next-intl/server";
 
 export async function generateMetadata({
@@ -20,84 +22,15 @@ export default async function Home({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+
+  const portfolioData = (await getCachedGlobal("portfolio", 1)()) as Portfolio;
   // Enable static rendering
   setRequestLocale(locale);
 
-  const images = [
-    {
-      id: 1,
-      src: "https://picsum.photos/id/237/2000/3000",
-      width: 2000,
-      height: 3000,
-      alt: "Image 1",
-    },
-    {
-      id: 2,
-      src: "https://picsum.photos/id/238/3000/2000",
-      width: 3000,
-      height: 2000,
-      alt: "Image 1",
-    },
-    {
-      id: 3,
-      src: "https://picsum.photos/id/236/4000/1500",
-      width: 4000,
-      height: 1500,
-      alt: "Image 1",
-    },
-    {
-      id: 4,
-      src: "https://picsum.photos/id/235/2000/2000",
-      width: 2000,
-      height: 2000,
-      alt: "Image 1",
-    },
-    {
-      id: 5,
-      src: "https://picsum.photos/id/233/3000/2000",
-      width: 3000,
-      height: 2000,
-      alt: "Image 1",
-    },
-    {
-      id: 6,
-      src: "https://picsum.photos/id/234/4000/1500",
-      width: 4000,
-      height: 1500,
-      alt: "Image 1",
-    },
-    {
-      id: 7,
-      src: "https://picsum.photos/id/232/2000/2000",
-      width: 2000,
-      height: 2000,
-      alt: "Image 1",
-    },
-    {
-      id: 8,
-      src: "https://picsum.photos/id/231/3000/2000",
-      width: 3000,
-      height: 2000,
-      alt: "Image 1",
-    },
-    {
-      id: 9,
-      src: "https://picsum.photos/id/230/2000/3000",
-      width: 2000,
-      height: 3000,
-      alt: "Image 1",
-    },
-    {
-      id: 10,
-      src: "https://picsum.photos/id/239/2000/2000",
-      width: 2000,
-      height: 2000,
-      alt: "Image 1",
-    },
-
-    // Add more images as needed
-  ];
-
+  const images =
+    portfolioData?.portfolio.map((image) => {
+      return image.image as Media;
+    }) || [];
   return (
     <main className="w-auto">
       <Masonry images={images} />

--- a/src/app/(portfolio)/[locale]/projects/[slug]/page.tsx
+++ b/src/app/(portfolio)/[locale]/projects/[slug]/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next";
+
+import configPromise from "@payload-config";
+import { getPayload, type RequiredDataFromCollectionSlug } from "payload";
+import { draftMode } from "next/headers";
+import React, { cache } from "react";
+
+import { RenderBlocks } from "@/blocks/RenderBlocks";
+import { generateMeta } from "@/utilities/generateMeta";
+import { Locale } from "@/i18n/routing";
+// import PageClient from "./page.client";
+// import { LivePreviewListener } from "@/components/LivePreviewListener";
+
+export async function generateStaticParams() {
+  const payload = await getPayload({ config: configPromise });
+  const pages = await payload.find({
+    collection: "project",
+    draft: false,
+    limit: 1000,
+    locale: "all",
+    overrideAccess: false,
+    pagination: false,
+  });
+
+  const params = pages.docs.flatMap(({ slug }) => {
+    if (!slug || typeof slug !== "object") return [];
+
+    return Object.entries(slug).map(([locale, localizedSlug]) => {
+      return {
+        locale,
+        slug: localizedSlug,
+      };
+    });
+  });
+  return params;
+}
+
+type Args = {
+  params: Promise<{
+    locale: Locale;
+    slug?: string;
+  }>;
+};
+
+export default async function Page({ params: paramsPromise }: Args) {
+  const { isEnabled: draft } = await draftMode();
+  const paramsProps = await paramsPromise;
+
+  const locale = paramsProps.locale;
+  const slug = paramsProps.slug || "home";
+  const url = "/" + slug;
+
+  const page: RequiredDataFromCollectionSlug<"project"> | null =
+    await queryProjectBySlug({
+      slug,
+      locale,
+    });
+
+  //   // Remove this code once your website is seeded
+  //   if (!page && slug === "home") {
+  //     page = homeStatic;
+  //   }
+
+  const { layout } = page;
+
+  return (
+    <article className="pt-16 pb-24">
+      {/* <PageClient /> */}
+      {/* Allows redirects for valid pages too */}
+      {/* <PayloadRedirects disableNotFound url={url} /> */}
+
+      {/* {draft && <LivePreviewListener />} */}
+
+      <h1 className="text-4xl font-bold text-center mb-8">{page?.title}</h1>
+      {layout && <RenderBlocks blocks={layout} />}
+    </article>
+  );
+}
+
+export async function generateMetadata({
+  params: paramsPromise,
+}: Args): Promise<Metadata> {
+  const paramsProps = await paramsPromise;
+
+  const locale = paramsProps.locale;
+  const slug = paramsProps.slug ?? "home";
+
+  // const { slugs = "home", locale } = await paramsPromise;
+  // const page = await queryProjectBySlug({
+  //   slug,
+  //   locale,
+  // });
+
+  // return generateMeta({ doc: page });
+  return {};
+}
+
+const queryProjectBySlug = cache(
+  async ({ slug, locale }: { slug: string; locale: Locale }) => {
+    // const { isEnabled: draft } = await draftMode();
+
+    const payload = await getPayload({ config: configPromise });
+
+    const result = await payload.find({
+      collection: "project",
+      // draft,
+      limit: 1,
+      locale,
+      pagination: false,
+      // overrideAccess: draft,
+      where: {
+        slug: {
+          equals: slug,
+        },
+      },
+    });
+
+    return result.docs?.[0] || null;
+  }
+);

--- a/src/blocks/Images/ImagesBlock.tsx
+++ b/src/blocks/Images/ImagesBlock.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import type { ImagesBlock as ImagesBlockProps, Media } from "@/payload-types";
+import Masonry from "@/components/molocules/MasonryGrid/MasonryGrid";
+
+export const ImagesBlock: React.FC<ImagesBlockProps> = ({ images }) => {
+  const pictures = images.map((image) => {
+    return image.image as Media;
+  });
+
+  return (
+    <div className="my-16">
+      <Masonry images={pictures} />
+    </div>
+  );
+};

--- a/src/blocks/Images/config.ts
+++ b/src/blocks/Images/config.ts
@@ -1,0 +1,24 @@
+import type { Block } from "payload";
+
+export const ImagesBlock: Block = {
+  slug: "images",
+  fields: [
+    {
+      name: "images",
+      type: "array",
+      label: "Images",
+      required: true,
+      minRows: 1,
+      fields: [
+        {
+          name: "image",
+          type: "upload",
+          relationTo: "media",
+          required: true,
+          label: "Image",
+        },
+      ],
+    },
+  ],
+  interfaceName: "ImagesBlock",
+};

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -1,0 +1,45 @@
+import React, { Fragment } from "react";
+
+import type { Project } from "@/payload-types";
+
+import { RichTextBlock } from "./RichText/RichtextBlock";
+import { ImagesBlock } from "./Images/ImagesBlock";
+
+const blockComponents = {
+  richText: RichTextBlock,
+  images: ImagesBlock,
+};
+
+export const RenderBlocks: React.FC<{
+  blocks: Project["layout"][0][];
+}> = (props) => {
+  const { blocks } = props;
+
+  const hasBlocks = blocks && Array.isArray(blocks) && blocks.length > 0;
+
+  if (hasBlocks) {
+    return (
+      <Fragment>
+        {blocks.map((block, index) => {
+          const { blockType } = block;
+
+          if (blockType && blockType in blockComponents) {
+            const Block = blockComponents[blockType];
+
+            if (Block) {
+              return (
+                <div className="my-16" key={index}>
+                  {/* @ts-expect-error there may be some mismatch between the expected types here */}
+                  <Block {...block} disableInnerContainer />
+                </div>
+              );
+            }
+          }
+          return null;
+        })}
+      </Fragment>
+    );
+  }
+
+  return null;
+};

--- a/src/blocks/RichText/RichtextBlock.tsx
+++ b/src/blocks/RichText/RichtextBlock.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import type { RichTextBlock as RichtextBlockProps } from "@/payload-types";
+import RichText from "@/components/RichText";
+
+export const RichTextBlock: React.FC<RichtextBlockProps> = ({ content }) => {
+  return (
+    <div className="my-16">
+      <RichText data={content} />
+    </div>
+  );
+};

--- a/src/blocks/RichText/config.ts
+++ b/src/blocks/RichText/config.ts
@@ -1,0 +1,25 @@
+import type { Block } from "payload";
+
+import {
+  FixedToolbarFeature,
+  lexicalEditor,
+} from "@payloadcms/richtext-lexical";
+
+export const RichTextBlock: Block = {
+  slug: "richText",
+  fields: [
+    {
+      name: "content",
+      type: "richText",
+      editor: lexicalEditor({
+        features: ({ defaultFeatures }) => {
+          return [...defaultFeatures, FixedToolbarFeature()];
+        },
+      }),
+      label: false,
+      required: true,
+      localized: true,
+    },
+  ],
+  interfaceName: "RichTextBlock",
+};

--- a/src/collections/Projects/hooks/revalidatePage.ts
+++ b/src/collections/Projects/hooks/revalidatePage.ts
@@ -1,0 +1,50 @@
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+} from "payload";
+
+import { revalidatePath, revalidateTag } from "next/cache";
+import { Project } from "@/payload-types";
+
+export const revalidatePage: CollectionAfterChangeHook<Project> = ({
+  doc,
+  previousDoc,
+  req: { payload, context },
+}) => {
+  if (!context.disableRevalidate) {
+    if (doc._status === "published") {
+      const path = doc.slug === "home" ? "/" : `/${doc.slug}`;
+
+      payload.logger.info(`Revalidating page at path: ${path}`);
+
+      revalidatePath(path);
+      revalidateTag("pages-sitemap");
+    }
+
+    // If the page was previously published, we need to revalidate the old path
+    if (previousDoc?._status === "published" && doc._status !== "published") {
+      // const oldPath = previousDoc.slug === 'home' ? '/' : `/${previousDoc.slug}`
+      const oldPath = `/${previousDoc.slug}`;
+
+      payload.logger.info(`Revalidating old page at path: ${oldPath}`);
+
+      revalidatePath(oldPath);
+      revalidateTag("pages-sitemap");
+    }
+  }
+  return doc;
+};
+
+export const revalidateDelete: CollectionAfterDeleteHook<Project> = ({
+  doc,
+  req: { context },
+}) => {
+  if (!context.disableRevalidate) {
+    // const path = doc?.slug === 'home' ? '/' : `/${doc?.slug}`
+    const path = `/${doc?.slug}`;
+    revalidatePath(path);
+    revalidateTag("pages-sitemap");
+  }
+
+  return doc;
+};

--- a/src/collections/Projects/index.ts
+++ b/src/collections/Projects/index.ts
@@ -1,0 +1,138 @@
+import type { CollectionConfig } from "payload";
+
+import { authenticated } from "../../access/authenticated";
+import { authenticatedOrPublished } from "../../access/authenticatedOrPublished";
+import { slugField } from "@/fields/slug";
+import { populatePublishedAt } from "../../hooks/populatePublishedAt";
+// import { generatePreviewPath } from '../../utilities/generatePreviewPath'
+import { revalidateDelete, revalidatePage } from "./hooks/revalidatePage";
+
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
+import { RichTextBlock } from "@/blocks/RichText/config";
+import { ImagesBlock } from "@/blocks/Images/config";
+
+export const Projects: CollectionConfig<"project"> = {
+  slug: "project",
+  access: {
+    create: authenticated,
+    delete: authenticated,
+    read: authenticatedOrPublished,
+    update: authenticated,
+  },
+  // This config controls what's populated by default when a page is referenced
+  // https://payloadcms.com/docs/queries/select#defaultpopulate-collection-config-property
+  // Type safe if the collection slug generic is passed to `CollectionConfig` - `CollectionConfig<'pages'>
+  defaultPopulate: {
+    title: true,
+    slug: true,
+  },
+  admin: {
+    defaultColumns: ["title", "slug", "updatedAt"],
+    // livePreview: {
+    //   url: ({ data, req }) => {
+    //     const path = generatePreviewPath({
+    //       slug: typeof data?.slug === 'string' ? data.slug : '',
+    //       collection: 'pages',
+    //       req,
+    //     })
+
+    //     return path
+    //   },
+    // },
+    // preview: (data, { req }) =>
+    //   generatePreviewPath({
+    //     slug: typeof data?.slug === 'string' ? data.slug : '',
+    //     collection: 'pages',
+    //     req,
+    //   }),
+    useAsTitle: "title",
+  },
+  fields: [
+    {
+      name: "title",
+      type: "text",
+      required: true,
+      localized: true,
+    },
+    {
+      name: "mainImage",
+      type: "upload",
+      relationTo: "media",
+      required: true,
+    },
+    {
+      type: "tabs",
+      tabs: [
+        {
+          fields: [
+            {
+              name: "layout",
+              type: "blocks",
+              blocks: [RichTextBlock, ImagesBlock],
+              required: true,
+              admin: {
+                initCollapsed: true,
+              },
+            },
+          ],
+          label: "Content",
+        },
+        {
+          name: "meta",
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+
+            MetaDescriptionField({}),
+            PreviewField({
+              // if the `generateUrl` function is configured
+              hasGenerateFn: true,
+
+              // field paths to match the target field for data
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
+    },
+    {
+      name: "publishedAt",
+      type: "date",
+      admin: {
+        position: "sidebar",
+      },
+    },
+    ...slugField(),
+  ],
+  hooks: {
+    afterChange: [revalidatePage],
+    beforeChange: [populatePublishedAt],
+    afterDelete: [revalidateDelete],
+  },
+  versions: {
+    drafts: {
+      autosave: {
+        interval: 100, // We set this interval for optimal live preview
+      },
+      schedulePublish: true,
+    },
+    maxPerDoc: 50,
+  },
+};

--- a/src/components/molocules/LangSelect/LangSelect.tsx
+++ b/src/components/molocules/LangSelect/LangSelect.tsx
@@ -1,29 +1,20 @@
 "use client";
-import { usePathname, useRouter } from "@/i18n/navigation";
 import { useLocale } from "next-intl";
 import { useState } from "react";
 import type { MouseEvent } from "react";
 
-export function LangSelect() {
+interface LangSelectProps {
+  onLangChange: (lang: string) => void;
+}
+
+export function LangSelect({ onLangChange }: LangSelectProps) {
   const locale = useLocale();
   const [isHovered, setIsHovered] = useState(false);
-  const pathname = usePathname();
-  const router = useRouter();
-
-  const pathSegments = pathname.split("/");
-  const slug = pathSegments[1] === "projects" ? pathSegments[2] : null;
 
   function langSelectHandler(event: MouseEvent<HTMLLIElement>): void {
     const lang = event.currentTarget.textContent?.toLocaleLowerCase() || "";
 
-    if (pathname === "/projects/[slug]" && slug) {
-      router.push(
-        { pathname: "/projects/[slug]", params: { slug } },
-        { locale: lang }
-      );
-    } else {
-      router.push({ pathname: pathname as "/" | "/about" }, { locale: lang });
-    }
+    onLangChange(lang);
   }
 
   return (

--- a/src/components/molocules/LangSelect/Langselect.stories.tsx
+++ b/src/components/molocules/LangSelect/Langselect.stories.tsx
@@ -22,5 +22,5 @@ type Story = StoryObj<typeof meta>;
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Base: Story = {
-  args: {},
+  args: { onLangChange: (lang: string) => console.log(lang) },
 };

--- a/src/components/molocules/MasonryGrid/MasonryGrid.tsx
+++ b/src/components/molocules/MasonryGrid/MasonryGrid.tsx
@@ -7,17 +7,10 @@ import { ImageModal } from "../ImageModal/ImageModal";
 import { useRef, useState } from "react";
 import { CSSTransition } from "react-transition-group";
 import { useDisplaySize } from "@/hooks/display";
-
-type ImageData = {
-  id: number;
-  width: number;
-  height: number;
-  src: string;
-  alt: string;
-};
+import { Media } from "@/payload-types";
 
 interface MasonryProps {
-  images: ImageData[];
+  images: Media[];
 }
 
 const Masonry: React.FC<MasonryProps> = ({ images }) => {
@@ -38,8 +31,8 @@ const Masonry: React.FC<MasonryProps> = ({ images }) => {
         >
           <ImageModal
             ref={nodeRef}
-            src={images[activeImage].src}
-            alt={images[activeImage].alt}
+            src={images[activeImage].url || ""}
+            alt={images[activeImage].alt || "Image description not available"}
             hasMany={images.length > 1}
             onLeftClick={function (): void {
               setActiveImage((prev) => {
@@ -64,13 +57,13 @@ const Masonry: React.FC<MasonryProps> = ({ images }) => {
         </CSSTransition>
       </Portal>
       <div className={"masonry"}>
-        {images.map(({ id, src, width, height, alt }, index) => (
+        {images.map(({ id, url, width, height, alt }, index) => (
           <div
             key={id}
             className={"item"}
             style={{
-              minWidth: `${width / 10}px`,
-              minHeight: `${height / 10}px`,
+              minWidth: `${(width ?? 100) / 15}px`,
+              minHeight: `${(height ?? 100) / 15}px`,
             }}
           >
             {/* <span
@@ -83,13 +76,15 @@ const Masonry: React.FC<MasonryProps> = ({ images }) => {
                   }}
                 >{`w:${width}-h:${height}`}</span> */}
             <Image
+              priority
               className={"image"}
               style={{ cursor: size !== "mobile" ? "pointer" : "default" }}
+              sizes={size !== "mobile" ? "auto" : "auto"}
               fill={size !== "mobile"}
-              width={size === "mobile" ? width : undefined}
-              height={size === "mobile" ? height : undefined}
-              src={src}
-              alt={alt}
+              width={size === "mobile" ? width || 100 : undefined}
+              height={size === "mobile" ? height || 100 : undefined}
+              src={url || ""}
+              alt={alt || "Image description not available"}
               onClick={() => {
                 if (size !== "mobile") {
                   setActiveImage(index);

--- a/src/components/molocules/NavigationBar/NavigationBar.stories.tsx
+++ b/src/components/molocules/NavigationBar/NavigationBar.stories.tsx
@@ -21,18 +21,42 @@ const meta = {
     projects: [
       {
         id: "project-1",
-        name: "Project 1",
-        url: "#",
+        name: {
+          en: "Project 1",
+          se: "Projekt 1",
+          hu: "Projekt 1",
+        },
+        url: {
+          en: "project-1",
+          se: "projekt-1",
+          hu: "projekt-1",
+        },
       },
       {
         id: "project-2",
-        name: "Project 2",
-        url: "#",
+        name: {
+          en: "Project 2",
+          se: "Projekt 2",
+          hu: "Projekt 2",
+        },
+        url: {
+          en: "project-2",
+          se: "projekt-2",
+          hu: "projekt-2",
+        },
       },
       {
         id: "project-3",
-        name: "Project 3",
-        url: "#",
+        name: {
+          en: "Project 3",
+          se: "Projekt 3",
+          hu: "Projekt 3",
+        },
+        url: {
+          en: "project-3",
+          se: "projekt-3",
+          hu: "projekt-3",
+        },
       },
     ],
     socialMedia: [

--- a/src/fields/slug/index.ts
+++ b/src/fields/slug/index.ts
@@ -1,45 +1,49 @@
-import type { CheckboxField, TextField } from 'payload'
+import type { CheckboxField, TextField } from "payload";
 
-import { formatSlugHook } from './formatSlug'
+import { formatSlugHook } from "./formatSlug";
 
 type Overrides = {
-  slugOverrides?: Partial<TextField>
-  checkboxOverrides?: Partial<CheckboxField>
-}
+  slugOverrides?: Partial<TextField>;
+  checkboxOverrides?: Partial<CheckboxField>;
+};
 
-type Slug = (fieldToUse?: string, overrides?: Overrides) => [TextField, CheckboxField]
+type Slug = (
+  fieldToUse?: string,
+  overrides?: Overrides
+) => [TextField, CheckboxField];
 
-export const slugField: Slug = (fieldToUse = 'title', overrides = {}) => {
-  const { slugOverrides, checkboxOverrides } = overrides
+export const slugField: Slug = (fieldToUse = "title", overrides = {}) => {
+  const { slugOverrides, checkboxOverrides } = overrides;
 
   const checkBoxField: CheckboxField = {
-    name: 'slugLock',
-    type: 'checkbox',
+    name: "slugLock",
+    type: "checkbox",
     defaultValue: true,
     admin: {
       hidden: true,
-      position: 'sidebar',
+      position: "sidebar",
     },
     ...checkboxOverrides,
-  }
+  };
 
   // @ts-expect-error - ts mismatch Partial<TextField> with TextField
   const slugField: TextField = {
-    name: 'slug',
-    type: 'text',
+    name: "slug",
+    type: "text",
+    label: "Slug",
     index: true,
-    label: 'Slug',
+    localized: true,
     ...(slugOverrides || {}),
     hooks: {
       // Kept this in for hook or API based updates
       beforeValidate: [formatSlugHook(fieldToUse)],
     },
     admin: {
-      position: 'sidebar',
+      position: "sidebar",
       ...(slugOverrides?.admin || {}),
       components: {
         Field: {
-          path: '@/fields/slug/SlugComponent#SlugComponent',
+          path: "@/fields/slug/SlugComponent#SlugComponent",
           clientProps: {
             fieldToUse,
             checkboxFieldPath: checkBoxField.name,
@@ -47,7 +51,7 @@ export const slugField: Slug = (fieldToUse = 'title', overrides = {}) => {
         },
       },
     },
-  }
+  };
 
-  return [slugField, checkBoxField]
-}
+  return [slugField, checkBoxField];
+};

--- a/src/globals/About/config.ts
+++ b/src/globals/About/config.ts
@@ -27,7 +27,7 @@ export const About: GlobalConfig = {
     {
       type: "array",
       name: "images",
-      label: "Images for the about page",
+      label: "Images for About page",
       required: true,
       minRows: 1,
       maxRows: 10,

--- a/src/globals/Portfolio/config.ts
+++ b/src/globals/Portfolio/config.ts
@@ -1,0 +1,32 @@
+import type { GlobalConfig } from "payload";
+
+import { revalidatePortfolio } from "./hooks/revalidatePortfolio";
+
+export const Portfolio: GlobalConfig = {
+  slug: "portfolio",
+  access: {
+    read: () => true,
+  },
+  fields: [
+    {
+      dbName: "portfolio",
+      type: "array",
+      name: "portfolio",
+      label: "Images for Portfolio page",
+      required: true,
+      minRows: 1,
+      fields: [
+        {
+          type: "upload",
+          name: "image",
+          label: "Image",
+          relationTo: "media",
+          required: true,
+        },
+      ],
+    },
+  ],
+  hooks: {
+    afterChange: [revalidatePortfolio],
+  },
+};

--- a/src/globals/Portfolio/hooks/revalidatePortfolio.ts
+++ b/src/globals/Portfolio/hooks/revalidatePortfolio.ts
@@ -1,0 +1,16 @@
+import type { GlobalAfterChangeHook } from "payload";
+
+import { revalidateTag } from "next/cache";
+
+export const revalidatePortfolio: GlobalAfterChangeHook = ({
+  doc,
+  req: { payload, context },
+}) => {
+  if (!context.disableRevalidate) {
+    payload.logger.info(`Revalidating Portfolio page...`);
+
+    revalidateTag("global_portfolio");
+  }
+
+  return doc;
+};

--- a/src/hooks/formatSlug.ts
+++ b/src/hooks/formatSlug.ts
@@ -1,0 +1,27 @@
+import type { FieldHook } from 'payload'
+
+const format = (val: string): string =>
+  val
+    .replace(/ /g, '-')
+    .replace(/[^\w-]+/g, '')
+    .toLowerCase()
+
+const formatSlug =
+  (fallback: string): FieldHook =>
+  ({ data, operation, originalDoc, value }) => {
+    if (typeof value === 'string') {
+      return format(value)
+    }
+
+    if (operation === 'create') {
+      const fallbackData = data?.[fallback] || originalDoc?.[fallback]
+
+      if (fallbackData && typeof fallbackData === 'string') {
+        return format(fallbackData)
+      }
+    }
+
+    return value
+  }
+
+export default formatSlug

--- a/src/hooks/populatePublishedAt.ts
+++ b/src/hooks/populatePublishedAt.ts
@@ -1,0 +1,15 @@
+import type { CollectionBeforeChangeHook } from 'payload'
+
+export const populatePublishedAt: CollectionBeforeChangeHook = ({ data, operation, req }) => {
+  if (operation === 'create' || operation === 'update') {
+    if (req.data && !req.data.publishedAt) {
+      const now = new Date()
+      return {
+        ...data,
+        publishedAt: now,
+      }
+    }
+  }
+
+  return data
+}

--- a/src/hooks/revalidateRedirects.ts
+++ b/src/hooks/revalidateRedirects.ts
@@ -1,0 +1,11 @@
+import type { CollectionAfterChangeHook } from 'payload'
+
+import { revalidateTag } from 'next/cache'
+
+export const revalidateRedirects: CollectionAfterChangeHook = ({ doc, req: { payload } }) => {
+  payload.logger.info(`Revalidating redirects`)
+
+  revalidateTag('redirects')
+
+  return doc
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -68,6 +68,8 @@ export interface Config {
   collections: {
     media: Media;
     users: User;
+    project: Project;
+    'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -76,6 +78,8 @@ export interface Config {
   collectionsSelect: {
     media: MediaSelect<false> | MediaSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
+    project: ProjectSelect<false> | ProjectSelect<true>;
+    'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -96,7 +100,13 @@ export interface Config {
     collection: 'users';
   };
   jobs: {
-    tasks: unknown;
+    tasks: {
+      schedulePublish: TaskSchedulePublish;
+      inline: {
+        input: unknown;
+        output: unknown;
+      };
+    };
     workflows: unknown;
   };
 }
@@ -230,6 +240,159 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "project".
+ */
+export interface Project {
+  id: string;
+  title: string;
+  mainImage: string | Media;
+  layout: (RichTextBlock | ImagesBlock)[];
+  meta?: {
+    title?: string | null;
+    /**
+     * Maximum upload file size: 12MB. Recommended file size for images is <500KB.
+     */
+    image?: (string | null) | Media;
+    description?: string | null;
+  };
+  publishedAt?: string | null;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "RichTextBlock".
+ */
+export interface RichTextBlock {
+  content: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'richText';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ImagesBlock".
+ */
+export interface ImagesBlock {
+  images: {
+    image: string | Media;
+    id?: string | null;
+  }[];
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'images';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs".
+ */
+export interface PayloadJob {
+  id: string;
+  /**
+   * Input data provided to the job
+   */
+  input?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  taskStatus?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  completedAt?: string | null;
+  totalTried?: number | null;
+  /**
+   * If hasError is true this job will not be retried
+   */
+  hasError?: boolean | null;
+  /**
+   * If hasError is true, this is the error that caused it
+   */
+  error?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * Task execution log
+   */
+  log?:
+    | {
+        executedAt: string;
+        completedAt: string;
+        taskSlug: 'inline' | 'schedulePublish';
+        taskID: string;
+        input?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        output?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        state: 'failed' | 'succeeded';
+        error?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        id?: string | null;
+      }[]
+    | null;
+  taskSlug?: ('inline' | 'schedulePublish') | null;
+  queue?: string | null;
+  waitUntil?: string | null;
+  processing?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -242,6 +405,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'users';
         value: string | User;
+      } | null)
+    | ({
+        relationTo: 'project';
+        value: string | Project;
+      } | null)
+    | ({
+        relationTo: 'payload-jobs';
+        value: string | PayloadJob;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -396,6 +567,87 @@ export interface UsersSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "project_select".
+ */
+export interface ProjectSelect<T extends boolean = true> {
+  title?: T;
+  mainImage?: T;
+  layout?:
+    | T
+    | {
+        richText?: T | RichTextBlockSelect<T>;
+        images?: T | ImagesBlockSelect<T>;
+      };
+  meta?:
+    | T
+    | {
+        title?: T;
+        image?: T;
+        description?: T;
+      };
+  publishedAt?: T;
+  slug?: T;
+  slugLock?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "RichTextBlock_select".
+ */
+export interface RichTextBlockSelect<T extends boolean = true> {
+  content?: T;
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ImagesBlock_select".
+ */
+export interface ImagesBlockSelect<T extends boolean = true> {
+  images?:
+    | T
+    | {
+        image?: T;
+        id?: T;
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs_select".
+ */
+export interface PayloadJobsSelect<T extends boolean = true> {
+  input?: T;
+  taskStatus?: T;
+  completedAt?: T;
+  totalTried?: T;
+  hasError?: T;
+  error?: T;
+  log?:
+    | T
+    | {
+        executedAt?: T;
+        completedAt?: T;
+        taskSlug?: T;
+        taskID?: T;
+        input?: T;
+        output?: T;
+        state?: T;
+        error?: T;
+        id?: T;
+      };
+  taskSlug?: T;
+  queue?: T;
+  waitUntil?: T;
+  processing?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents_select".
  */
 export interface PayloadLockedDocumentsSelect<T extends boolean = true> {
@@ -497,6 +749,23 @@ export interface PortfolioSelect<T extends boolean = true> {
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TaskSchedulePublish".
+ */
+export interface TaskSchedulePublish {
+  input: {
+    type?: ('publish' | 'unpublish') | null;
+    locale?: string | null;
+    doc?: {
+      relationTo: 'project';
+      value: string | Project;
+    } | null;
+    global?: string | null;
+    user?: (string | null) | User;
+  };
+  output?: unknown;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -85,9 +85,11 @@ export interface Config {
   };
   globals: {
     about: About;
+    portfolio: Portfolio;
   };
   globalsSelect: {
     about: AboutSelect<false> | AboutSelect<true>;
+    portfolio: PortfolioSelect<false> | PortfolioSelect<true>;
   };
   locale: 'en' | 'se' | 'hu';
   user: User & {
@@ -454,11 +456,39 @@ export interface About {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "portfolio".
+ */
+export interface Portfolio {
+  id: string;
+  portfolio: {
+    image: string | Media;
+    id?: string | null;
+  }[];
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "about_select".
  */
 export interface AboutSelect<T extends boolean = true> {
   aboutMe?: T;
   images?:
+    | T
+    | {
+        image?: T;
+        id?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "portfolio_select".
+ */
+export interface PortfolioSelect<T extends boolean = true> {
+  portfolio?:
     | T
     | {
         image?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -6,18 +6,14 @@ import path from "path";
 import { buildConfig, PayloadRequest } from "payload";
 import { fileURLToPath } from "url";
 
-// import { Categories } from "./collections/Categories";
 import { Media } from "./collections/Media";
-// import { Pages } from "./collections/Pages";
-// import { Posts } from "./collections/Posts";
 import { Users } from "./collections/Users";
-// import { Footer } from "./Footer/config";
-// import { Header } from "./Header/config";
 import { plugins } from "./plugins";
 import { defaultLexical } from "@/fields/defaultLexical";
 import { getServerSideURL } from "./utilities/getURL";
 import { About } from "./globals/About/config";
 import { Portfolio } from "./globals/Portfolio/config";
+import { Projects } from "./collections/Projects";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -68,7 +64,7 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.DATABASE_URI || "",
   }),
-  collections: [Media, Users],
+  collections: [Media, Users, Projects],
   globals: [About, Portfolio],
   cors: [getServerSideURL()].filter(Boolean),
   //globals: [],

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -17,6 +17,7 @@ import { plugins } from "./plugins";
 import { defaultLexical } from "@/fields/defaultLexical";
 import { getServerSideURL } from "./utilities/getURL";
 import { About } from "./globals/About/config";
+import { Portfolio } from "./globals/Portfolio/config";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -68,7 +69,7 @@ export default buildConfig({
     url: process.env.DATABASE_URI || "",
   }),
   collections: [Media, Users],
-  globals: [About],
+  globals: [About, Portfolio],
   cors: [getServerSideURL()].filter(Boolean),
   //globals: [],
   plugins: [

--- a/src/utilities/generateMeta.ts
+++ b/src/utilities/generateMeta.ts
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+
+import type { Media, Project, Config } from "../payload-types";
+
+import { mergeOpenGraph } from "./mergeOpenGraph";
+import { getServerSideURL } from "./getURL";
+
+const getImageURL = (image?: Media | Config["db"]["defaultIDType"] | null) => {
+  const serverUrl = getServerSideURL();
+
+  let url = serverUrl + "/website-template-OG.webp";
+
+  if (image && typeof image === "object" && "url" in image) {
+    const ogUrl = image.sizes?.og?.url;
+
+    url = ogUrl ? serverUrl + ogUrl : serverUrl + image.url;
+  }
+
+  return url;
+};
+
+export const generateMeta = async (args: {
+  doc: Partial<Project> | null;
+}): Promise<Metadata> => {
+  const { doc } = args;
+
+  const ogImage = getImageURL(doc?.meta?.image);
+
+  const title = doc?.meta?.title
+    ? doc?.meta?.title + " | Payload Website Template"
+    : "Payload Website Template";
+
+  return {
+    description: doc?.meta?.description,
+    openGraph: mergeOpenGraph({
+      description: doc?.meta?.description || "",
+      images: ogImage
+        ? [
+            {
+              url: ogImage,
+            },
+          ]
+        : undefined,
+      title,
+      url: Array.isArray(doc?.slug) ? doc?.slug.join("/") : "/",
+    }),
+    title,
+  };
+};

--- a/src/utilities/getGlobals.ts
+++ b/src/utilities/getGlobals.ts
@@ -6,13 +6,12 @@ import { unstable_cache } from "next/cache";
 
 type Global = keyof Config["globals"];
 
-async function getGlobal(slug: Global, locale: Config["locale"], depth = 0) {
+async function getGlobal(slug: Global, depth = 0) {
   const payload = await getPayload({ config: configPromise });
 
   const global = await payload.findGlobal({
     slug,
     depth,
-    locale: locale,
   });
 
   return global;
@@ -21,13 +20,9 @@ async function getGlobal(slug: Global, locale: Config["locale"], depth = 0) {
 /**
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
-export const getCachedGlobal = (
-  slug: Global,
-  locale: Config["locale"],
-  depth = 0
-) => {
-  console.log("getCachedGlobal", slug, locale, depth);
-  return unstable_cache(async () => getGlobal(slug, locale, depth), [slug], {
+export const getCachedGlobal = (slug: Global, depth = 0) => {
+  console.log("getCachedGlobal", slug, depth);
+  return unstable_cache(async () => getGlobal(slug, depth), [slug], {
     tags: [`global_${slug}`],
   });
 };

--- a/src/utilities/getGlobals.ts
+++ b/src/utilities/getGlobals.ts
@@ -21,7 +21,6 @@ async function getGlobal(slug: Global, depth = 0) {
  * Returns a unstable_cache function mapped with the cache tag for the slug
  */
 export const getCachedGlobal = (slug: Global, depth = 0) => {
-  console.log("getCachedGlobal", slug, depth);
   return unstable_cache(async () => getGlobal(slug, depth), [slug], {
     tags: [`global_${slug}`],
   });

--- a/src/utilities/mergeOpenGraph.ts
+++ b/src/utilities/mergeOpenGraph.ts
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import { getServerSideURL } from './getURL'
+
+const defaultOpenGraph: Metadata['openGraph'] = {
+  type: 'website',
+  description: 'An open-source website built with Payload and Next.js.',
+  images: [
+    {
+      url: `${getServerSideURL()}/website-template-OG.webp`,
+    },
+  ],
+  siteName: 'Payload Website Template',
+  title: 'Payload Website Template',
+}
+
+export const mergeOpenGraph = (og?: Metadata['openGraph']): Metadata['openGraph'] => {
+  return {
+    ...defaultOpenGraph,
+    ...og,
+    images: og?.images ? og.images : defaultOpenGraph.images,
+  }
+}


### PR DESCRIPTION
This pull request includes significant updates to the project, focusing on importing SEO components, enhancing the portfolio layout, and adding new blocks and hooks for project management. The most important changes are grouped by theme as follows:

### SEO Component Integration:
* Added imports for various SEO components from `@payloadcms/plugin-seo/client` to `src/app/(payload)/admin/importMap.js` and updated the `importMap` to include these components. [[1]](diffhunk://#diff-d8fcf2008238d20b6b3128406e49030f949593ccf484c4f4b79a9fb86579195fR24-R29) [[2]](diffhunk://#diff-d8fcf2008238d20b6b3128406e49030f949593ccf484c4f4b79a9fb86579195fL48-R60)

### Portfolio Layout Enhancements:
* Updated `src/app/(portfolio)/[locale]/layout.tsx` to import and use the `Project` component, added a `queryProject` function to fetch project data, and passed the fetched projects to the `NavigationBar` component. ([src/app/(portfolio)/[locale]/layout.tsxL4-R14](diffhunk://#diff-083d4d235140a92531d09bcc7c8be70d81ae2c92f0d61ac85347d40bbf969be7L4-R14), [src/app/(portfolio)/[locale]/layout.tsxR46](diffhunk://#diff-083d4d235140a92531d09bcc7c8be70d81ae2c92f0d61ac85347d40bbf969be7R46), [src/app/(portfolio)/[locale]/layout.tsxL52-R59](diffhunk://#diff-083d4d235140a92531d09bcc7c8be70d81ae2c92f0d61ac85347d40bbf969be7L52-R59), [src/app/(portfolio)/[locale]/layout.tsxR68-R92](diffhunk://#diff-083d4d235140a92531d09bcc7c8be70d81ae2c92f0d61ac85347d40bbf969be7R68-R92))
* Modified `src/app/(portfolio)/[locale]/page.tsx` to fetch and use portfolio data from `getCachedGlobal` instead of hardcoded images. ([src/app/(portfolio)/[locale]/page.tsxR2-R3](diffhunk://#diff-926c9cbc55fb13b32ae34d300094f20459cd225c36ea5f106d264496fcc55ac0R2-R3), [src/app/(portfolio)/[locale]/page.tsxR25-R33](diffhunk://#diff-926c9cbc55fb13b32ae34d300094f20459cd225c36ea5f106d264496fcc55ac0R25-R33))

### Project Page and Blocks:
* Created a new project page in `src/app/(portfolio)/[locale]/projects/[slug]/page.tsx` with functions to generate static params and metadata, and to query project data by slug. ([src/app/(portfolio)/[locale]/projects/[slug]/page.tsxR1-R120](diffhunk://#diff-857c7fda66e978f14ab18b1a225acd774639e67c09fa9a42740ac95fa7889d17R1-R120))
* Added `ImagesBlock` and `RichTextBlock` components and their configurations in `src/blocks/Images/ImagesBlock.tsx`, `src/blocks/Images/config.ts`, `src/blocks/RichText/RichtextBlock.tsx`, and `src/blocks/RichText/config.ts`. [[1]](diffhunk://#diff-93ccd2aec527617a8c980eab42e51a78465fafab022b83b0f13d5c8ea2f4f015R1-R15) [[2]](diffhunk://#diff-859ec982a955c139770482c772c9085482331e042368e8a141877006a03121e0R1-R24) [[3]](diffhunk://#diff-2b04042316ab6380f6806fabeff1ad0ed44e8bd82a191b589ef9a07bcaabae1aR1-R11) [[4]](diffhunk://#diff-dc6d2ee57f6ea020a81ccde1f93b3680b1b2f23c59c4685d06ff73f78568ad33R1-R25)
* Implemented `RenderBlocks` component to dynamically render different block types.

### Project Collection and Hooks:
* Defined the `Projects` collection in `src/collections/Projects/index.ts` with fields for title, main image, layout, and SEO metadata, and hooks for revalidating pages.
* Added hooks for revalidating pages on change or delete in `src/collections/Projects/hooks/revalidatePage.ts`.

### Language Selection:
* Updated `LangSelect` component to accept an `onLangChange` prop and removed direct routing logic.
* Modified `Langselect.stories.tsx` to include the `onLangChange` prop in the story args.