### PR TITLE
reorganized Portal and image viewer, clean the clutter

### DIFF
--- a/src/app/(portfolio)/[locale]/layout.tsx
+++ b/src/app/(portfolio)/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { setRequestLocale } from 'next-intl/server';
 import configPromise from '@payload-config';
 import { getPayload } from 'payload';
 import { cache } from 'react';
+import { ImagesProvider } from '@/components/providers/ImageProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -56,8 +57,10 @@ export default async function RootLayout({
           <div id='myportal' />
           <div className='flex p-8 md:p-14 lg:p-20 justify-center'>
             <div className='flex gap-4 w-full max-w-[1200px]'>
-              <NavigationBar projects={projects} socialMedia={[]} />
-              {children}
+              <ImagesProvider>
+                <NavigationBar projects={projects} socialMedia={[]} />
+                {children}
+              </ImagesProvider>
             </div>
           </div>
         </body>

--- a/src/app/(portfolio)/[locale]/page.client.tsx
+++ b/src/app/(portfolio)/[locale]/page.client.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { ImagesContext } from '@/components/providers/ImageProvider';
+import { Media } from '@/payload-types';
+import React, { useContext, useEffect } from 'react';
+
+interface PageClientProps {
+  images: Media[];
+}
+
+const PageClient: React.FC<PageClientProps> = ({ images }) => {
+  const { setImages } = useContext(ImagesContext);
+
+  useEffect(() => {
+    setImages(images);
+  }, [images, setImages]);
+
+  return <></>;
+};
+
+export default PageClient;

--- a/src/app/(portfolio)/[locale]/page.tsx
+++ b/src/app/(portfolio)/[locale]/page.tsx
@@ -2,6 +2,7 @@ import Masonry from '@/components/molecules/MasonryGrid/MasonryGrid';
 import { Media, Portfolio } from '@/payload-types';
 import { getCachedGlobal } from '@/utilities/getGlobals';
 import { setRequestLocale } from 'next-intl/server';
+import PageClient from './page.client';
 
 export async function generateMetadata({
   params,
@@ -33,6 +34,7 @@ export default async function Home({
     }) || [];
   return (
     <main className='w-auto'>
+      <PageClient images={images} />
       <Masonry images={images} />
     </main>
   );

--- a/src/app/(portfolio)/[locale]/projects/[slug]/page.client.tsx
+++ b/src/app/(portfolio)/[locale]/projects/[slug]/page.client.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { ImagesContext } from '@/components/providers/ImageProvider';
+import { ImagesBlock, Media, RichTextBlock } from '@/payload-types';
+import React, { useContext, useEffect } from 'react';
+import Image from 'next/image';
+import { RenderBlocks } from '@/blocks/RenderBlocks';
+
+interface PageClientProps {
+  mainImage: Media;
+  layout: (ImagesBlock | RichTextBlock)[];
+}
+
+const PageClient: React.FC<PageClientProps> = ({ mainImage, layout }) => {
+  const { setImages, setCurrentImageId } = useContext(ImagesContext);
+
+  useEffect(() => {
+    const collectedImages = [mainImage];
+    setCurrentImageId('');
+    layout.map((block) => {
+      if (block.blockType === 'images') {
+        (block as ImagesBlock).images.forEach((image) => {
+          collectedImages.push(image.image as Media);
+        });
+      }
+    });
+    setImages(collectedImages);
+  }, [mainImage, layout, setImages, setCurrentImageId]);
+
+  const handleMainImageClick = () => {
+    setCurrentImageId(mainImage.id);
+  };
+
+  return (
+    <>
+      <Image
+        className='self-center w-full h-auto aspect-[3/1] md:w-[80%] md:h-auto'
+        style={{
+          objectFit: 'cover',
+          objectPosition: 'center',
+          cursor: 'pointer',
+        }}
+        src={mainImage.url || ''}
+        alt={mainImage.alt || ''}
+        width={1000}
+        height={500}
+        onClick={handleMainImageClick}
+      />
+
+      {layout && <RenderBlocks blocks={layout} />}
+    </>
+  );
+};
+
+export default PageClient;

--- a/src/app/(portfolio)/[locale]/projects/[slug]/page.tsx
+++ b/src/app/(portfolio)/[locale]/projects/[slug]/page.tsx
@@ -1,31 +1,30 @@
-import type { Metadata } from "next";
+import type { Metadata } from 'next';
 
-import configPromise from "@payload-config";
-import { getPayload, type RequiredDataFromCollectionSlug } from "payload";
-import { draftMode } from "next/headers";
-import React, { cache } from "react";
+import configPromise from '@payload-config';
+import { getPayload, type RequiredDataFromCollectionSlug } from 'payload';
+// import { draftMode } from 'next/headers';
+import React, { cache } from 'react';
 
-import { RenderBlocks } from "@/blocks/RenderBlocks";
-import { generateMeta } from "@/utilities/generateMeta";
-import { Locale } from "@/i18n/routing";
-import Image from "next/image";
-import { Media } from "@/payload-types";
+import { generateMeta } from '@/utilities/generateMeta';
+import { Locale } from '@/i18n/routing';
+import { Media } from '@/payload-types';
+import PageClient from './page.client';
 // import PageClient from "./page.client";
 // import { LivePreviewListener } from "@/components/LivePreviewListener";
 
 export async function generateStaticParams() {
   const payload = await getPayload({ config: configPromise });
   const pages = await payload.find({
-    collection: "project",
+    collection: 'project',
     draft: false,
     limit: 1000,
-    locale: "all",
+    locale: 'all',
     overrideAccess: false,
     pagination: false,
   });
 
   const params = pages.docs.flatMap(({ slug }) => {
-    if (!slug || typeof slug !== "object") return [];
+    if (!slug || typeof slug !== 'object') return [];
 
     return Object.entries(slug).map(([locale, localizedSlug]) => {
       return {
@@ -45,14 +44,14 @@ type Args = {
 };
 
 export default async function Page({ params: paramsPromise }: Args) {
-  const { isEnabled: draft } = await draftMode();
+  // const { isEnabled: draft } = await draftMode();
   const paramsProps = await paramsPromise;
 
   const locale = paramsProps.locale;
-  const slug = paramsProps.slug || "home";
-  const url = "/" + slug;
+  const slug = paramsProps.slug || 'home';
+  // const url = '/' + slug;
 
-  const page: RequiredDataFromCollectionSlug<"project"> | null =
+  const page: RequiredDataFromCollectionSlug<'project'> | null =
     await queryProjectBySlug({
       slug,
       locale,
@@ -67,15 +66,16 @@ export default async function Page({ params: paramsPromise }: Args) {
   const { layout } = page;
 
   return (
-    <article className="flex flex-col gap-12">
+    <article className='flex flex-col gap-12'>
       {/* <PageClient /> */}
       {/* Allows redirects for valid pages too */}
       {/* <PayloadRedirects disableNotFound url={url} /> */}
 
       {/* {draft && <LivePreviewListener />} */}
 
-      <h1 className="text-4xl font-bold">{page?.title}</h1>
-      <Image
+      <h1 className='text-4xl font-bold'>{page?.title}</h1>
+      <PageClient mainImage={mainImage} layout={layout} />
+      {/* <Image
         className="self-center w-full h-auto aspect-[3/1] md:w-[80%] md:h-auto"
         style={{
           objectFit: "cover",
@@ -87,7 +87,7 @@ export default async function Page({ params: paramsPromise }: Args) {
         height={500}
       />
 
-      {layout && <RenderBlocks blocks={layout} />}
+      {layout && <RenderBlocks blocks={layout} />} */}
     </article>
   );
 }
@@ -98,16 +98,16 @@ export async function generateMetadata({
   const paramsProps = await paramsPromise;
 
   const locale = paramsProps.locale;
-  const slug = paramsProps.slug ?? "home";
+  const slug = paramsProps.slug ?? 'home';
 
   // const { slugs = "home", locale } = await paramsPromise;
-  // const page = await queryProjectBySlug({
-  //   slug,
-  //   locale,
-  // });
+  const page = await queryProjectBySlug({
+    slug,
+    locale,
+  });
 
-  // return generateMeta({ doc: page });
-  return {};
+  return generateMeta({ doc: page });
+  // return {};
 }
 
 const queryProjectBySlug = cache(
@@ -117,7 +117,7 @@ const queryProjectBySlug = cache(
     const payload = await getPayload({ config: configPromise });
 
     const result = await payload.find({
-      collection: "project",
+      collection: 'project',
       // draft,
       limit: 1,
       locale,

--- a/src/components/molecules/MasonryGrid/MasonryGrid.tsx
+++ b/src/components/molecules/MasonryGrid/MasonryGrid.tsx
@@ -1,101 +1,50 @@
-"use client";
+'use client';
 
-import Image from "next/image";
-import "./Masonry.css";
-import Portal from "@/components/Portal/Portal";
-import { ImageModal } from "../ImageModal/ImageModal";
-import { useRef, useState } from "react";
-import { CSSTransition } from "react-transition-group";
-import { useDisplaySize } from "@/hooks/display";
-import { Media } from "@/payload-types";
+import Image from 'next/image';
+import './Masonry.css';
+import { useContext } from 'react';
+import { useDisplaySize } from '@/hooks/display';
+import { Media } from '@/payload-types';
+import { ImagesContext } from '@/components/providers/ImageProvider';
 
 interface MasonryProps {
   images: Media[];
 }
 
 const Masonry: React.FC<MasonryProps> = ({ images }) => {
-  const [activeImage, setActiveImage] = useState(0);
-  const [isOpen, setIsOpen] = useState(false);
-  const nodeRef = useRef(null);
   const size = useDisplaySize();
+  const imageContext = useContext(ImagesContext);
 
   return (
-    <>
-      <Portal>
-        <CSSTransition
-          in={isOpen}
-          nodeRef={nodeRef}
-          timeout={300}
-          classNames="modal"
-          unmountOnExit
+    <div className={'masonry'}>
+      {images.map(({ id, url, width, height, alt }) => (
+        <div
+          key={id}
+          className={'item'}
+          style={{
+            minWidth: `${(width ?? 100) / 15}px`,
+            minHeight: `${(height ?? 100) / 15}px`,
+          }}
         >
-          <ImageModal
-            ref={nodeRef}
-            src={images[activeImage].url || ""}
-            alt={images[activeImage].alt || "Image description not available"}
-            hasMany={images.length > 1}
-            onLeftClick={function (): void {
-              setActiveImage((prev) => {
-                if (prev === 0) {
-                  return images.length - 1;
-                }
-                return prev - 1;
-              });
-            }}
-            onRightClick={function (): void {
-              setActiveImage((prev) => {
-                if (prev === images.length - 1) {
-                  return 0;
-                }
-                return prev + 1;
-              });
-            }}
-            onClose={function (): void {
-              setIsOpen(false);
+          <Image
+            priority
+            className={'image'}
+            style={{ cursor: size !== 'mobile' ? 'pointer' : 'default' }}
+            sizes={size !== 'mobile' ? 'auto' : 'auto'}
+            fill={size !== 'mobile'}
+            width={size === 'mobile' ? width || 100 : undefined}
+            height={size === 'mobile' ? height || 100 : undefined}
+            src={url || ''}
+            alt={alt || 'Image description not available'}
+            onClick={() => {
+              if (size !== 'mobile') {
+                imageContext.setCurrentImageId(id);
+              }
             }}
           />
-        </CSSTransition>
-      </Portal>
-      <div className={"masonry"}>
-        {images.map(({ id, url, width, height, alt }, index) => (
-          <div
-            key={id}
-            className={"item"}
-            style={{
-              minWidth: `${(width ?? 100) / 15}px`,
-              minHeight: `${(height ?? 100) / 15}px`,
-            }}
-          >
-            {/* <span
-                  style={{
-                    color: "#ff00ff",
-                    top: "10px",
-                    left: "10px",
-                    position: "absolute",
-                    zIndex: 1,
-                  }}
-                >{`w:${width}-h:${height}`}</span> */}
-            <Image
-              priority
-              className={"image"}
-              style={{ cursor: size !== "mobile" ? "pointer" : "default" }}
-              sizes={size !== "mobile" ? "auto" : "auto"}
-              fill={size !== "mobile"}
-              width={size === "mobile" ? width || 100 : undefined}
-              height={size === "mobile" ? height || 100 : undefined}
-              src={url || ""}
-              alt={alt || "Image description not available"}
-              onClick={() => {
-                if (size !== "mobile") {
-                  setActiveImage(index);
-                  setIsOpen(true);
-                }
-              }}
-            />
-          </div>
-        ))}
-      </div>
-    </>
+        </div>
+      ))}
+    </div>
   );
 };
 

--- a/src/components/molecules/ProfileImage/ProfileImage.tsx
+++ b/src/components/molecules/ProfileImage/ProfileImage.tsx
@@ -11,7 +11,8 @@ interface ProfileImageProps {
 
 export const ProfileImage: React.FC<ProfileImageProps> = ({ images }) => {
   const [main, ...others] = images;
-  const [currentImage, setCurrentImage] = useState(0);
+  console.log('others', others);
+  const [currentImage, setCurrentImage] = useState(others.length - 1);
   const [isHovered, setIsHovered] = useState(false);
 
   return (

--- a/src/components/providers/ImageProvider.tsx
+++ b/src/components/providers/ImageProvider.tsx
@@ -1,0 +1,93 @@
+'use client';
+import { Media } from '@/payload-types';
+import { createContext, useEffect, useRef, useState } from 'react';
+import Portal from '@/components/Portal/Portal';
+
+import { CSSTransition } from 'react-transition-group';
+import { ImageModal } from '../molecules/ImageModal/ImageModal';
+
+interface ImagesContextType {
+  setCurrentImageId: (index: string) => void;
+  setImages: (images: Media[]) => void;
+}
+
+export const ImagesContext = createContext<ImagesContextType>({
+  setCurrentImageId: () => {},
+  setImages: () => {},
+});
+
+interface ImagesProviderProps {
+  children: React.ReactNode;
+}
+
+export const ImagesProvider: React.FC<ImagesProviderProps> = ({ children }) => {
+  const [images, setImages] = useState<Media[]>([]);
+  const [currentImageId, setCurrentImageId] = useState('');
+  const [activeImage, setActiveImage] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const nodeRef = useRef(null);
+
+  useEffect(() => {
+    if (currentImageId) {
+      const index = images.findIndex((image) => image.id === currentImageId);
+      if (index !== -1) {
+        setActiveImage(index);
+        setIsOpen(true);
+      }
+    }
+  }, [currentImageId, images]);
+
+  return (
+    <ImagesContext.Provider
+      value={{
+        setCurrentImageId,
+        setImages,
+      }}
+    >
+      <>
+        <Portal>
+          <CSSTransition
+            in={isOpen}
+            nodeRef={nodeRef}
+            timeout={300}
+            classNames='modal'
+            unmountOnExit
+          >
+            {images.length > 0 && (
+              <ImageModal
+                ref={nodeRef}
+                src={images[activeImage].url || ''}
+                alt={
+                  images[activeImage].alt || 'Image description not available'
+                }
+                hasMany={images.length > 1}
+                onLeftClick={function (): void {
+                  setActiveImage((prev) => {
+                    if (prev === 0) {
+                      return images.length - 1;
+                    }
+                    return prev - 1;
+                  });
+                }}
+                onRightClick={function (): void {
+                  setActiveImage((prev) => {
+                    if (prev === images.length - 1) {
+                      return 0;
+                    }
+                    return prev + 1;
+                  });
+                }}
+                onClose={function (): void {
+                  setIsOpen(false);
+                  setCurrentImageId('');
+                }}
+              />
+            )}
+          </CSSTransition>
+        </Portal>
+        {children}
+      </>
+    </ImagesContext.Provider>
+  );
+};


### PR DESCRIPTION
This pull request introduces a new `ImagesProvider` and updates various components to utilize this provider for managing image states. The most important changes include wrapping components with the `ImagesProvider`, creating a new `PageClient` component, and refactoring existing components to use the new context.

### Introduction of `ImagesProvider`:

* `src/app/(portfolio)/[locale]/layout.tsx`: Added `ImagesProvider` to wrap the `NavigationBar` and children components. ([src/app/(portfolio)/[locale]/layout.tsxR15](diffhunk://#diff-083d4d235140a92531d09bcc7c8be70d81ae2c92f0d61ac85347d40bbf969be7R15), [src/app/(portfolio)/[locale]/layout.tsxR60-R63](diffhunk://#diff-083d4d235140a92531d09bcc7c8be70d81ae2c92f0d61ac85347d40bbf969be7R60-R63))
* [`src/components/providers/ImageProvider.tsx`](diffhunk://#diff-c99c890ea54ee5d06797d80c89b4cdbb47c187f1235186ddc31013a80ba2e973R1-R93): Created a new `ImagesProvider` component to manage image states and context.

### Creation of `PageClient` components:

* `src/app/(portfolio)/[locale]/page.client.tsx`: Added a new `PageClient` component to manage image states on the client side. ([src/app/(portfolio)/[locale]/page.client.tsxR1-R20](diffhunk://#diff-bd011e46ac0fd036336699e4d96248aae35238516c7adb70a7c983459b407c8eR1-R20))
* `src/app/(portfolio)/[locale]/projects/[slug]/page.client.tsx`: Added another `PageClient` component for project-specific image management. ([src/app/(portfolio)/[locale]/projects/[slug]/page.client.tsxR1-R54](diffhunk://#diff-1a2b5e13e2f3b395f27e6a0753d0ba67bc814a491bba8d9f467f4654c5830723R1-R54))

### Updates to existing components:

* `src/app/(portfolio)/[locale]/page.tsx`: Imported and used `PageClient` to manage images in the `Home` component. ([src/app/(portfolio)/[locale]/page.tsxR5](diffhunk://#diff-926c9cbc55fb13b32ae34d300094f20459cd225c36ea5f106d264496fcc55ac0R5), [src/app/(portfolio)/[locale]/page.tsxR37](diffhunk://#diff-926c9cbc55fb13b32ae34d300094f20459cd225c36ea5f106d264496fcc55ac0R37))
* `src/app/(portfolio)/[locale]/projects/[slug]/page.tsx`: Refactored to use `PageClient` and removed unused code related to image handling. ([src/app/(portfolio)/[locale]/projects/[slug]/page.tsxL1-R27](diffhunk://#diff-857c7fda66e978f14ab18b1a225acd774639e67c09fa9a42740ac95fa7889d17L1-R27), [src/app/(portfolio)/[locale]/projects/[slug]/page.tsxL48-R54](diffhunk://#diff-857c7fda66e978f14ab18b1a225acd774639e67c09fa9a42740ac95fa7889d17L48-R54), [src/app/(portfolio)/[locale]/projects/[slug]/page.tsxL70-R78](diffhunk://#diff-857c7fda66e978f14ab18b1a225acd774639e67c09fa9a42740ac95fa7889d17L70-R78), [src/app/(portfolio)/[locale]/projects/[slug]/page.tsxL90-R90](diffhunk://#diff-857c7fda66e978f14ab18b1a225acd774639e67c09fa9a42740ac95fa7889d17L90-R90), [src/app/(portfolio)/[locale]/projects/[slug]/page.tsxL101-R110](diffhunk://#diff-857c7fda66e978f14ab18b1a225acd774639e67c09fa9a42740ac95fa7889d17L101-R110), [src/app/(portfolio)/[locale]/projects/[slug]/page.tsxL120-R120](diffhunk://#diff-857c7fda66e978f14ab18b1a225acd774639e67c09fa9a42740ac95fa7889d17L120-R120))
* [`src/components/molecules/MasonryGrid/MasonryGrid.tsx`](diffhunk://#diff-cd07c3a9a7e084463f1977c456a17f9024455763453417e9c6788bb0a034eec5L1-L98): Updated to use `ImagesContext` for image state management instead of local state.
* [`src/components/molecules/ProfileImage/ProfileImage.tsx`](diffhunk://#diff-d9d1c9fe5a0a3f1bdc642e8eb7529c66e0d00c09cf7a5b5ab5b100a293aa78b8L14-R15): Minor update to the initial state of `currentImage`.