### PR TITLE
refactor of portrait image

### DIFF
--- a/src/app/(portfolio)/[locale]/about/page.client.tsx
+++ b/src/app/(portfolio)/[locale]/about/page.client.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { ProfileImage } from '@/components/molecules/ProfileImage/ProfileImage';
+import { DisplayContext } from '@/components/providers/DisplayProvider';
+import { About, Media } from '@/payload-types';
+import { RichText } from '@payloadcms/richtext-lexical/react';
+import React, { useContext } from 'react';
+
+interface PageClientProps {
+  images: Media[];
+  aboutMe: About['aboutMe'];
+}
+
+const PageClient: React.FC<PageClientProps> = ({ images, aboutMe }) => {
+  const { display } = useContext(DisplayContext);
+
+  return (
+    <>
+      {display !== null && (
+        <div className='w-full flex flex-col md:flex-row md:space-between gap-4 rich-text'>
+          <RichText data={aboutMe} />
+          <div className='flex flex-row justify-center md:flex-col '>
+            <ProfileImage images={images} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default PageClient;

--- a/src/app/(portfolio)/[locale]/about/page.tsx
+++ b/src/app/(portfolio)/[locale]/about/page.tsx
@@ -1,12 +1,11 @@
-import RichText from '@/components/RichText';
 import { Locale } from '@/i18n/routing';
 import type { About, Media } from '@/payload-types';
 import { getLocale, setRequestLocale } from 'next-intl/server';
 import { getPayload } from 'payload';
 import configPromise from '@payload-config';
-import { ProfileImage } from '@/components/molecules/ProfileImage/ProfileImage';
 import { generateMetaForGlobal } from '@/utilities/generateMeta';
 import type { Metadata } from 'next';
+import PageClient from './page.client';
 
 type Args = {
   params: Promise<{
@@ -33,19 +32,7 @@ export default async function About() {
 
   setRequestLocale(locale);
 
-  return (
-    <>
-      {global.id && (
-        <div className='w-full flex flex-col md:flex-row md:space-between gap-4'>
-          <RichText data={aboutMe} />
-
-          <div className='flex flex-row md:flex-col '>
-            <ProfileImage images={images} />
-          </div>
-        </div>
-      )}
-    </>
-  );
+  return <>{global.id && <PageClient images={images} aboutMe={aboutMe} />}</>;
 }
 
 export async function generateMetadata({

--- a/src/components/molecules/ProfileImage/ProfileImage.tsx
+++ b/src/components/molecules/ProfileImage/ProfileImage.tsx
@@ -2,6 +2,7 @@
 import { Media } from '@/payload-types';
 import Image from 'next/image';
 import { useState } from 'react';
+import ImageWithSkeleton from '../Image/ImageWithSkeleton';
 
 const TRANSITION_DURATION = 300;
 
@@ -23,18 +24,20 @@ export const ProfileImage: React.FC<ProfileImageProps> = ({ images }) => {
       }}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <Image
+      <ImageWithSkeleton
         style={{
           width: '100%',
           height: 'auto',
           aspectRatio: '2/3',
           objectFit: 'cover',
+          minWidth: '250px',
         }}
         src={main.url || ''}
         alt={main.alt || 'Image description not available'}
         width={300}
         height={200}
       />
+
       <div
         className={`absolute top-0 left-0 right-0 bottom-0 
           ${isHovered ? 'opacity-100' : 'opacity-0'} 
@@ -42,6 +45,7 @@ export const ProfileImage: React.FC<ProfileImageProps> = ({ images }) => {
       >
         {others.length !== 0 && (
           <Image
+            className='rounded'
             style={{
               width: '100%',
               height: 'auto',


### PR DESCRIPTION
This pull request refactors the `about` page in the portfolio app by introducing a client-side component for rendering and enhances the `ProfileImage` component with a new image wrapper and additional styles. These changes improve the separation of concerns and enhance the user experience.

### Refactoring the `about` page:

* **Client-side rendering for `about` page content**: Extracted the client-side logic into a new `PageClient` component (`page.client.tsx`) to handle rendering of `aboutMe` and `images` using the `RichText` and `ProfileImage` components. This improves the separation of server-side and client-side responsibilities. (`[src/app/(portfolio)/[locale]/about/page.client.tsxR1-R30](diffhunk://#diff-6de523e39ff481fb9a562fd6abd3ca2a0b211ca8e4d20493f204e3938d97f63dR1-R30)`, `[src/app/(portfolio)/[locale]/about/page.tsxL36-R35](diffhunk://#diff-1998509d9fbb5a607e11330bdbc62dbd9c09381ee190b7561f93edb9149d6196L36-R35)`)
* **Simplified server-side `About` function**: Updated the `About` function in `page.tsx` to delegate rendering to the new `PageClient` component, reducing complexity in the server-side code. (`[src/app/(portfolio)/[locale]/about/page.tsxL36-R35](diffhunk://#diff-1998509d9fbb5a607e11330bdbc62dbd9c09381ee190b7561f93edb9149d6196L36-R35)`)

### Enhancements to the `ProfileImage` component:

* **Use of `ImageWithSkeleton`**: Replaced the `Image` component with `ImageWithSkeleton` in `ProfileImage` to provide a better loading experience with skeleton placeholders. (`[[1]](diffhunk://#diff-d9d1c9fe5a0a3f1bdc642e8eb7529c66e0d00c09cf7a5b5ab5b100a293aa78b8R5)`, `[[2]](diffhunk://#diff-d9d1c9fe5a0a3f1bdc642e8eb7529c66e0d00c09cf7a5b5ab5b100a293aa78b8L26-R48)`)
* **Improved styling**: Added a `minWidth` property and a `rounded` class to enhance the visual appearance of images in the `ProfileImage` component. (`[src/components/molecules/ProfileImage/ProfileImage.tsxL26-R48](diffhunk://#diff-d9d1c9fe5a0a3f1bdc642e8eb7529c66e0d00c09cf7a5b5ab5b100a293aa78b8L26-R48)`)